### PR TITLE
Use correct dependency for greensock/gsap/tweenmax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
   },
   "dependencies": {
     "jquery": "~1.11.0",
-    "greensock-js": "latest"
+    "gsap": "latest"
   }
 }


### PR DESCRIPTION
The correct bower dependency for gsap is 'gsap' which is maintained by the GreenSock team
